### PR TITLE
Add a message box in case of no search results on homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -136,6 +136,7 @@ h1, h2 {
   border-radius: 5px;
   border: none;
   padding: 20px 20px;
+  text-overflow: ellipsis;
   width: 100%;
 }
 
@@ -152,6 +153,13 @@ h1, h2 {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   width: 100%;
+}
+
+#no-output {
+  text-align: center; 
+  color: var(--text-color); 
+  background: inherit; 
+  font-size: small;
 }
 
 #count-output {

--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
       <div class="circle"></div>
     </div>
     <div id="output"></div>
+    <div id="no-output" style="display: none;">No results found. Please try again later.</div>
     <a id="scroll_button" href="#navbar" class="float-button">
       <img class="float-img" src="images/arrow.svg" alt="up">
     </a>

--- a/script.js
+++ b/script.js
@@ -80,17 +80,21 @@ async function loadEntryCount() {
 function search_entries() {
   let base_element = document.getElementsByClassName("search");
   let input = base_element[0].getElementsByTagName("input")[0].value;
-  input = input.toLowerCase();
+  input = input.trim().toLowerCase();   // Using trim() for removing any surrounding whitespaces, and toLowerCase() for converting its case to lowercase so as to perform a case-insensitive search
 
   let data = document.getElementById("output").childNodes;
+  let result_count = 0;
 
   for (i = 0; i < data.length; i++) {
     if (!data[i].innerHTML.toLowerCase().includes(input)) {
       data[i].style.display = "none";
     } else {
       data[i].style.display = "inline";
+      result_count++;
     }
   }
+
+  $('#no-output').css('display', (result_count>0)?'none':'block'); // setting display css property for 'no results found ...' <div> block based on result_count using jQuery, Shorthand for: if (result_count==0) $('#no-output').css('display', 'block'); else $('#no-output').css('display', 'none');
 }
 
 $(window).scroll(function (event) {


### PR DESCRIPTION
This pull request includes a commit that slightly enhances the search experience by displaying a message "No results found. Please try again later." for the case when a query in a search box is not found on the available list of entries. This will be useful as the user will not be waiting for search results and will get a confirmed response in case the CSV source datasheet does not include it.

Here's how it would look:
![No_Result](https://user-images.githubusercontent.com/57865187/135720622-1a8b70d1-bb36-4a74-b558-86870312572c.png)

Please have a look, and comment down if anything else is needed on it, and merge it if it seems fine and ready to be included.
