### PR TITLE
Fixed index page link in about navbar

### DIFF
--- a/about.html
+++ b/about.html
@@ -39,7 +39,7 @@
       style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   <ul id="navbar">
-    <li class="selected"><a href="/">Home</a></li>
+    <li class="selected"><a href="index.html">Home</a></li>
     <li><a href="about.html">About Us</a></li>
     <li><a href="https://github.com/many-passwords/many-passwords/blob/main/CONTRIBUTING.md"
         target="_blank">Contributing</a></li>


### PR DESCRIPTION
This is a small bug I found in the about.html page. The href to the index page was missing in the navbar. I hope this helps.